### PR TITLE
chore(deps): bump fastapi to 0.117 (starlette 0.49 blocked by upstream)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.12.*"
 license = { text = "AGPL-3.0-or-later" }
 authors = [{ name = "Zynksec Maintainers" }]
 dependencies = [
-  "fastapi>=0.116,<0.117",
+  "fastapi>=0.116,<0.118",
   "pydantic>=2.9,<3",
   "pydantic-settings>=2.6,<3",
   "uvicorn[standard]>=0.32,<0.33",

--- a/uv.lock
+++ b/uv.lock
@@ -180,16 +180,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.116.2"
+version = "0.117.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/64/1296f46d6b9e3b23fb22e5d01af3f104ef411425531376212f1eefa2794d/fastapi-0.116.2.tar.gz", hash = "sha256:231a6af2fe21cfa2c32730170ad8514985fc250bec16c9b242d3b94c835ef529", size = 298595, upload-time = "2025-09-16T18:29:23.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/7e/d9788300deaf416178f61fb3c2ceb16b7d0dc9f82a08fdb87a5e64ee3cc7/fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a", size = 307155, upload-time = "2025-09-20T20:16:56.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/e4/c543271a8018874b7f682bf6156863c416e1334b8ed3e51a69495c5d4360/fastapi-0.116.2-py3-none-any.whl", hash = "sha256:c3a7a8fb830b05f7e087d920e0d786ca1fc9892eb4e9a84b227be4c1bc7569db", size = 95670, upload-time = "2025-09-16T18:29:21.329Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/45/d9d3e8eeefbe93be1c50060a9d9a9f366dba66f288bb518a9566a23a8631/fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552", size = 95959, upload-time = "2025-09-20T20:16:53.661Z" },
 ]
 
 [[package]]
@@ -915,7 +915,7 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13,<2" },
     { name = "celery", specifier = ">=5.4,<6" },
-    { name = "fastapi", specifier = ">=0.116,<0.117" },
+    { name = "fastapi", specifier = ">=0.116,<0.118" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2,<4" },
     { name = "pydantic", specifier = ">=2.9,<3" },
     { name = "pydantic-settings", specifier = ">=2.6,<3" },


### PR DESCRIPTION
FastAPI 0.117 still caps starlette below 0.49, so the Range header DoS CVE in starlette cannot be closed by a uv lock bump alone. Dismissing the alert separately with a 'risk tolerable' rationale since this project has no FileResponse routes.

## Summary

<!-- 1-3 bullets describing what changed and, more importantly, why. -->

## Context / links

- Issue: <!-- #123 -->
- Docs touched: <!-- docs/... -->
- ADR: <!-- docs/decisions/... if any -->

## Testing

<!-- How was this verified? Commands run, files inspected, screenshots. -->

- [ ] `pre-commit run --all-files` is green
- [ ] `docker compose up -d` cold-starts cleanly (if infra changed)
- [ ] `mypy --strict packages/shared-schema` is green (if schema changed)
- [ ] Docs updated (`docs/`, `README.md`, or inline docstrings)

## Risk / rollback

<!-- What breaks if this is wrong? How to revert safely? -->

## Screenshots (UI only)

<!-- Delete if not applicable. -->
